### PR TITLE
Fixing bug with running test_nem in timezones ahead of Melbourne

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 nemweb.egg-info/
 *.ipynb_checkpoints/
 *.pytest_cache/
+test.db

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ __pycache__/
 build/
 dist/
 nemweb.egg-info/
-
+*.ipynb_checkpoints/
+*.pytest_cache/

--- a/nemweb/tests/test_nemweb.py
+++ b/nemweb/tests/test_nemweb.py
@@ -8,7 +8,7 @@ import pytest
 from nemweb import CONFIG
 from nemweb.nemweb_current import CurrentFileHandler, DATASETS
 
-from nemweb.utils import local_to_nem_tz
+from nemweb.utils import utc_to_nem
 
 DB_PATH = os.path.join(
     CONFIG['local_settings']['sqlite_dir'], 'test.db')
@@ -23,8 +23,10 @@ def nemweb_current():
     handler = CurrentFileHandler()
 
     #test latest previous trading_interval
-    local_datetime = datetime.datetime.now()
-    nemtime = local_to_nem_tz(local_datetime)
+    # local_datetime = datetime.datetime.now()
+    # nemtime = local_to_nem_tz(local_datetime)
+    nemtime = utc_to_nem()
+
     start_datetime = nemtime - datetime.timedelta(0, 1800)
 
     handler.update_data(

--- a/nemweb/tests/test_utils.py
+++ b/nemweb/tests/test_utils.py
@@ -1,0 +1,20 @@
+import pytest
+import pytz
+
+from nemweb.utils import local_to_nem_tz, utc_to_nem
+from datetime import datetime as dt
+
+
+@pytest.mark.parametrize(
+    'utc, expected',
+    (
+        #  simple 10 hours ahead
+        (dt(2019, 1, 21, 0, 0, 0), dt(2019, 1, 21, 10, 0, 0, 0)),
+        #  covering two days
+        (dt(2025, 12, 4, 23, 0, 0), dt(2025, 12, 5, 9, 0, 0)),
+    )
+)
+def test_utc_to_nem(utc, expected):
+    assert expected == utc_to_nem(utc)
+
+#  TODO same test for local_to_nem_tz

--- a/nemweb/utils.py
+++ b/nemweb/utils.py
@@ -43,3 +43,16 @@ def local_to_nem_tz(dt):
 
     #return new timezone (naive)
     return dt_nem.replace(tzinfo=None)
+
+
+def utc_to_nem(now=None):
+    """
+    Converts from UTC to nemtime
+
+    Assuming nemtime is Aussie Eastern Standard Time
+    -> 10 hour offset all year round
+    """
+    if not now:
+        now = datetime.datetime.utcnow()
+
+    return now + datetime.timedelta(hours=10)


### PR DESCRIPTION
Reworked how `start_datetime` is calculated in testing - now uses a 10 hour offset from UTC rather than assuming user is in Melbourne.