### PR TITLE
Added nemweb folder as the install folder to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,5 @@ setup(name='nemweb',
           'requests'],
       cmdclass={'install': PostInstallCommand,
                 'develop': PostDevelopCommand},
-      package_data={'nemweb': 'tests/2018_09_21.pkl'}
+      package_data={'nemweb': 'nemweb'}
       )


### PR DESCRIPTION
Running 

`python3 setup.py install `

out of the box does not install nemweb as a testing folder was left in setup.py