### PR TITLE
Bugfix: update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,5 @@ setup(name='nemweb',
           'requests'],
       cmdclass={'install': PostInstallCommand,
                 'develop': PostDevelopCommand},
-      package_data={'nemweb': 'tests/2018_09_21.pkl'}
+      package_data={'nemweb': ['tests/2018_09_21.pkl']}
       )


### PR DESCRIPTION
When running `python3 setup.py install` you get the following error:

```
error in nemweb setup command: "values of 'package_data' dict" must be a list of strings (got 'tests/2018_09_21.pkl')
```

This PR fixes it.